### PR TITLE
Removed repositories key from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
     ],
     "type": "symfony-bundle",
     "license": "EUPL",
-    "repositories": {
-        "minvws/audit-logger": {
-            "type": "vcs",
-            "url": "git@github.com:minvws/nl-rdo-php-audit-logger.git"
-        }
-    },
     "require": {
         "php": "^8.1",
         "doctrine/doctrine-bundle": "^2.11",


### PR DESCRIPTION
Removed repositories key from composer.json because the dependency is available through packagist now